### PR TITLE
Fix misspelling issue#2

### DIFF
--- a/.claude/commands/generate-prp.md
+++ b/.claude/commands/generate-prp.md
@@ -4,7 +4,7 @@
 
 Generate a complete PRP for general feature implementation with thorough research. Ensure context is passed to the AI agent to enable self-validation and iterative refinement. Read the feature file first to understand what needs to be created, how the examples provided help, and any other considerations.
 
-The AI agent only gets the context you are appending to the PRP and training data. Assuma the AI agent has access to the codebase and the same knowledge cutoff as you, so its important that your research findings are included or referenced in the PRP. The Agent has Websearch capabilities, so pass urls to documentation and examples.
+The AI agent only gets the context you are appending to the PRP and training data. Assume the AI agent has access to the codebase and the same knowledge cutoff as you, so its important that your research findings are included or referenced in the PRP. The Agent has Websearch capabilities, so pass urls to documentation and examples.
 
 ## Research Process
 

--- a/.claude/commands/generate-prp.md
+++ b/.claude/commands/generate-prp.md
@@ -38,7 +38,7 @@ Using PRPs/templates/prp_base.md as template:
 - Start with pseudocode showing approach
 - Reference real files for patterns
 - Include error handling strategy
-- list tasks to be completed to fullfill the PRP in the order they should be completed
+- list tasks to be completed to fulfill the PRP in the order they should be completed
 
 ### Validation Gates (Must be Executable) eg for python
 ```bash


### PR DESCRIPTION
## Description
- Fixes #2: Correct 'Assuma' → 'Assume' in 'generate-prp.md'.
- Fix incidental typo: 'fullfill' → 'fulfill' (US spelling).