### PR TITLE
fix: remove unsupported frontmatter attributes from SKILL.md

### DIFF
--- a/use-cases/build-with-agent-team/SKILL.md
+++ b/use-cases/build-with-agent-team/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: build-with-agent-team
 description: Build a project using Claude Code Agent Teams with tmux split panes. Takes a plan document path and optional team size. Use when you want multiple agents collaborating on a build.
-argument-hint: [plan-path] [num-agents]
-disable-model-invocation: true
 ---
 
 # Build with Agent Team


### PR DESCRIPTION
Remove 'argument-hint' and 'disable-model-invocation' from the skill frontmatter as they are not supported attributes. Claude Code skill files only support: name, description, compatibility, license, and metadata.

Arguments are still passed via $ARGUMENTS and work without argument-hint.
---
Big fan of your content, thanks for putting this together! 🙌